### PR TITLE
Fix typo in documentation related to CACHE

### DIFF
--- a/man/getAnnotationHubOption.Rd
+++ b/man/getAnnotationHubOption.Rd
@@ -31,7 +31,7 @@ setAnnotationHubOption(arg, value)
 
     \item{\dQuote{CACHE}:}{character(1). The location of the hub
       cache. Default: \dQuote{AnnotationHub} in the user's directory
-      established by \code{rappdir::user_cache_dir}.}
+      established by \code{rappdirs::user_cache_dir()}.}
 
     \item{\dQuote{MAX_DOWNLOADS}:}{numeric(1). The integer number of
       downloads allowed before triggering an error. This is to help


### PR DESCRIPTION
Caught a typo -- should be "rappdirs" instead of "rappdir".