### PR TITLE
make more examples runnable in docs

### DIFF
--- a/man/Hub-utils.Rd
+++ b/man/Hub-utils.Rd
@@ -56,12 +56,9 @@ given resources download size.
   collected is ah_id, fetch_id, title, rdataclass, availablitiy status,
   biocversion when added, date when added, date when removed, and file size.}
 \examples{
-
-\dontrun{
+hub <- AnnotationHub()
 getInfoOnIds(hub, c("AH2","AH5012"))
 getInfoOnIds(hub, 69303)
-
-}
 
 # If using in conjunction with convertHub,
 #

--- a/man/convertHub.Rd
+++ b/man/convertHub.Rd
@@ -44,8 +44,15 @@ convertHub(oldcachepath=NULL,
   also prints status messages for downloading files and any files that
   were not redownloaded.}
 \examples{
+## new default location
+newloc <- tools::R_user_dir("AnnotationHub", which = "cache")
+newloc
+\dontrun{
+## old default location
+oldloc <- rappdirs::user_cache_dir("AnnotationHub")
 # To transition over from old default to new default location
-convertHub()
+convertHub(oldcachepath=oldloc, newcachepath=newloc)
+}
 }
 \author{Lori Shepherd}
 \seealso{\code{\link{AnnotationHub}},

--- a/man/convertHub.Rd
+++ b/man/convertHub.Rd
@@ -45,7 +45,7 @@ convertHub(oldcachepath=NULL,
   were not redownloaded.}
 \examples{
 # To transition over from old default to new default location
-\dontrun{convertHub()}
+convertHub()
 }
 \author{Lori Shepherd}
 \seealso{\code{\link{AnnotationHub}},

--- a/man/listResources.Rd
+++ b/man/listResources.Rd
@@ -11,13 +11,18 @@
 
 \description{
   List and load resources from ExperimentHub filtered by package
-  name and optional search terms. Not Implemented for
+  name and optional search terms. Methods not implemented for
   AnnotationHub.
 }
 
 \details{
   Currently \code{listResources} and \code{loadResources} are only meaningful
   for \code{ExperimentHub} objects.
+}
+
+\examples{
+    getGeneric("listResources")
+    getGeneric("loadResources")
 }
 
 \keyword{utilities}


### PR DESCRIPTION
Hi Lori, @lshep 
This should resolve the `BiocCheck` error: 

```r
✖ ERROR: At least 80% of man pages documenting exported objects must have
runnable examples.
The following pages do not:
• AnnotationHubResource-class.Rd
• ...
• listResources.Rd
```

Note. `listResources.Rd` should probably document the generic. I only added some runnable examples. 