### PR TITLE
use BiocBaseUtils::selectSome

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Description: This package provides a client for the Bioconductor
 License: Artistic-2.0
 Depends: BiocGenerics (>= 0.15.10), BiocFileCache (>= 2.99.3)
 Imports: utils, methods, grDevices, RSQLite, BiocManager, BiocVersion, curl, rappdirs,
-    AnnotationDbi (>= 1.31.19), S4Vectors, httr2, yaml, dplyr
+    AnnotationDbi (>= 1.31.19), S4Vectors, httr2, yaml, dplyr, BiocBaseUtils
 Suggests: IRanges, Seqinfo, GenomeInfoDb, GenomicRanges, VariantAnnotation,
     Rsamtools, rtracklayer, BiocStyle, knitr, AnnotationForge, rBiopaxParser,
     RUnit, txdbmaker, MSnbase, mzR, Biostrings, CompoundDb, keras,

--- a/R/db-utils.R
+++ b/R/db-utils.R
@@ -57,7 +57,7 @@ setMethod("dbfile", "Hub",
     bad <- value[!value %in% .db_uid(x)]
     if (any(bad))
         stop("invalid subscripts: ",
-             paste(sQuote(S4Vectors:::selectSome(bad)), collapse=", "))
+             paste(sQuote(BiocBaseUtils::selectSome(bad)), collapse=", "))
     slot(x, ".db_uid") <- value
     x
 }


### PR DESCRIPTION
This addresses one of the packages listed in the `NOTE`: 

```r
* checking dependencies in R code ... NOTE
Unexported objects imported by ':::' calls:
  'BiocFileCache:::.get_tbl_rid' 'S4Vectors:::selectSome'
  See the note in ?`:::` about the use of this operator.
```